### PR TITLE
(HAL-01) Locking of the pragma version and update version

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Installation
 
 1. Clone the repository `git clone git@github.com:figment-networks/figment-eth2-depositor.git`
 2. Install the npm dependencies `npm install`
-3. Set a working version of the compiler `npx truffle obtain --solc v0.8.1+commit.df193b15`
+3. Set a working version of the compiler `npx truffle obtain --solc v0.8.10+commit.fc410830`
 
 Deployment (Goerli)
 ------------

--- a/contracts/FigmentEth2Depositor.sol
+++ b/contracts/FigmentEth2Depositor.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.10;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/security/Pausable.sol";

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -60,7 +60,7 @@
    // Configure your compilers
    compilers: {
      solc: {
-       version: "v0.8.1+commit.df193b15", // Fetch exact version from solc-bin (default: truffle's version)
+       version: "v0.8.10+commit.fc410830", // Fetch exact version from solc-bin (default: truffle's version)
        settings: {
          "remappings": [],
          "optimizer": {


### PR DESCRIPTION
Description: 
The contract should be deployed using the same compiler version and flags used during development and testing. Locking the pragma helps it.

Resolution:
- Locking the pragma version to **0.8.10** in `FigmentEth2Depositor.sol`
- Locking the pragma version in truffle-config.js
- Update the README with the locked compiler version
