### PR TITLE
(HAL-02) remove ReentrancyGuard.sol as it's unused

### DIFF
--- a/contracts/FigmentEth2Depositor.sol
+++ b/contracts/FigmentEth2Depositor.sol
@@ -4,10 +4,9 @@ pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/security/Pausable.sol";
-import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "../contracts/interfaces/IDepositContract.sol";
 
-contract FigmentEth2Depositor is ReentrancyGuard, Pausable, Ownable {
+contract FigmentEth2Depositor is Pausable, Ownable {
 
     /**
      * @dev Eth2 Deposit Contract address.


### PR DESCRIPTION
**Description:**
The contract import the **ReentrancyGuard.sol** contract and inherits from it but then the **nonReentrant** modifier is not used anywhere in the code.

**Resolution:**
Remove **ReentrancyGuard** import/inheritance** from the smart contract.