### PR TITLE
(HAL-03) Declare the state variable depositContract as immutable to save some gas

### DIFF
--- a/contracts/FigmentEth2Depositor.sol
+++ b/contracts/FigmentEth2Depositor.sol
@@ -31,14 +31,9 @@ contract FigmentEth2Depositor is ReentrancyGuard, Pausable, Ownable {
     /**
      * @dev Setting Eth2 Smart Contract address during construction.
      */
-    constructor(bool mainnet, address depositContract_) {
-        if (mainnet == true) {
-            depositContract = IDepositContract(0x00000000219ab540356cBB839Cbe05303d7705Fa);
-        } else if (depositContract_ == 0x0000000000000000000000000000000000000000) {
-            depositContract = IDepositContract(0x8c5fecdC472E27Bc447696F431E425D02dd46a8c);
-        } else {
-            depositContract = IDepositContract(depositContract_);
-        }
+    constructor(address depositContract_) {
+        require(depositContract_ != address(0), "Zero address");
+        depositContract = IDepositContract(depositContract_);
     }
 
     /**


### PR DESCRIPTION
**Description**:
The state variable `depositContract` can be declared as **immutable** to save some gas.

**Resolution**:
Adding the `immutable` modifier to `depositContract` state variable.