### PR TITLE
(HAL-04) replace public by external to save some gas cost

### DIFF
--- a/contracts/FigmentEth2Depositor.sol
+++ b/contracts/FigmentEth2Depositor.sol
@@ -99,7 +99,7 @@ contract FigmentEth2Depositor is ReentrancyGuard, Pausable, Ownable {
      *
      * - The contract must not be paused.
      */
-    function pause() public onlyOwner {
+    function pause() external onlyOwner {
       _pause();
     }
 
@@ -110,7 +110,7 @@ contract FigmentEth2Depositor is ReentrancyGuard, Pausable, Ownable {
      *
      * - The contract must be paused.
      */
-    function unpause() public onlyOwner {
+    function unpause() external onlyOwner {
       _unpause();
     }
 


### PR DESCRIPTION
**Description:**
The function `pause()` and `unpause()` are marked as public but they are never directly called within the smart contract or in any of their descendants.

**Resolution**
Mark all these functions as `external` to reduce gas costs.