### PR TITLE
(HAL-05) no need to initialize uint256 to 0 as it's default to 0

### DIFF
--- a/contracts/FigmentEth2Depositor.sol
+++ b/contracts/FigmentEth2Depositor.sol
@@ -75,7 +75,7 @@ contract FigmentEth2Depositor is ReentrancyGuard, Pausable, Ownable {
             deposit_data_roots.length == nodesAmount,
             "FigmentEth2Depositor: amount of parameters do no match");
 
-        for (uint256 i = 0; i < nodesAmount; ++i) {
+        for (uint256 i; i < nodesAmount; ++i) {
             require(pubkeys[i].length == pubkeyLength, "FigmentEth2Depositor: wrong pubkey");
             require(withdrawal_credentials[i].length == credentialsLength, "FigmentEth2Depositor: wrong withdrawal credentials");
             require(signatures[i].length == signatureLength, "FigmentEth2Depositor: wrong signatures");


### PR DESCRIPTION
**Description**
As `i` is an `uint256`, it is already initialized to 0.

**Resolution**
Replace `uint256 I = 0` with `uint256 i`