### PR TITLE
Renames contracts for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This project includes an example Ignition module to deploy the contract. You can
 To run the deployment to a local chain:
 
 ```shell
-pnpm hardhat ignition deploy ignition/modules/FigmentEth2Depositor.ts
+pnpm hardhat ignition deploy ignition/modules/FigmentEth2DepositorV0.ts
 ```
 
 To run the deployment to Sepolia, you need an account with funds to send the transaction. The provided Hardhat configuration includes a Configuration Variable called `SEPOLIA_PRIVATE_KEY`, which you can use to set the private key of the account you want to use.
@@ -67,7 +67,7 @@ Below is a list of contracts we use for this service:
 </dl>
 
 <dl>
-  <dt>FigmentEth2Depositor0x01</dt>
+  <dt>FigmentEth2DepositorV0</dt>
   <dd>A smart contract that accepts X amount of ETH and sends {x / 32} transactions with required collateral (32 ETH) to the Eth2 Deposit Contract.</dd>
 </dl>
 
@@ -76,4 +76,4 @@ Below is a list of contracts we use for this service:
 1. Choose the amount of Eth2 validator nodes you want to deposit to.
 2. Instantiate those validators with your chosen `withdrawal_credentials`
 3. Retrieve your validators' `pubkeys`, and generate `deposit_signatures` and `deposit_data_roots` from each that will let you deposit to them.
-4. Use the _deposit()_ function on `FigmentEth2Depositor` with the required ETH value to make the deposits to the Eth2 Deposit Contract.
+4. Use the _deposit()_ function on `FigmentEth2DepositorV0` with the required ETH value to make the deposits to the Eth2 Deposit Contract.

--- a/contracts/FigmentEth2DepositorV0.sol
+++ b/contracts/FigmentEth2DepositorV0.sol
@@ -6,7 +6,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/Pausable.sol";
 import "../contracts/interfaces/IDepositContract.sol";
 
-contract FigmentEth2Depositor0x01 is Pausable, Ownable {
+contract FigmentEth2DepositorV0 is Pausable, Ownable {
 
     /**
      * @dev Eth2 Deposit Contract address.

--- a/contracts/FigmentEth2DepositorV0.t.sol
+++ b/contracts/FigmentEth2DepositorV0.t.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.28;
 
-import {FigmentEth2Depositor0x01} from "./FigmentEth2Depositor0x01.sol";
+import {FigmentEth2DepositorV0} from "./FigmentEth2DepositorV0.sol";
 import {Test} from "forge-std/src/Test.sol";
 
-contract FigmentEth2Depositor0x01Test is Test {
-  FigmentEth2Depositor0x01 depositor;
+contract FigmentEth2DepositorV0Test is Test {
+  FigmentEth2DepositorV0 depositor;
 
   function setUp() public {
     // Mock deposit contract address for testing
     address mockDepositContract = 0x00000000219ab540356cBB839Cbe05303d7705Fa;
-    depositor = new FigmentEth2Depositor0x01(mockDepositContract);
+    depositor = new FigmentEth2DepositorV0(mockDepositContract);
   }
 }

--- a/contracts/FigmentEth2DepositorV1.sol
+++ b/contracts/FigmentEth2DepositorV1.sol
@@ -7,14 +7,14 @@ import "@openzeppelin/contracts/utils/Pausable.sol";
 import "../contracts/interfaces/IDepositContract.sol";
 
 /**
- * @title FigmentEth2Depositor
+ * @title FigmentEth2DepositorV1
  * @notice Batch Ethereum 2.0 validator deposit contract with variable amounts
  * @dev Allows creating multiple validators in a single transaction with custom stake amounts
  * @dev Supports deposits between 32 ETH and 2048 ETH per validator
  * @dev Maximum 500 validators per transaction for gas efficiency
  * @author Figment
  */
-contract FigmentEth2Depositor is Pausable, Ownable {
+contract FigmentEth2DepositorV1 is Pausable, Ownable {
     /**
      * @dev Custom errors for better gas efficiency and debugging
      */

--- a/contracts/FigmentEth2DepositorV1.t.sol
+++ b/contracts/FigmentEth2DepositorV1.t.sol
@@ -1,36 +1,36 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.28;
 
-import {FigmentEth2Depositor} from "./FigmentEth2Depositor.sol";
+import {FigmentEth2DepositorV1} from "./FigmentEth2DepositorV1.sol";
 import {Test} from "forge-std/src/Test.sol";
 import {MockDepositContract} from "./MockDepositContract.sol";
 import {IDepositContract} from "./interfaces/IDepositContract.sol";
 import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 
-contract FigmentEth2DepositorTest is Test {
-    FigmentEth2Depositor figmentDepositor;
+contract FigmentEth2DepositorV1Test is Test {
+    FigmentEth2DepositorV1 figmentDepositor;
     MockDepositContract mockDepositContract;
 
     function setUp() public {
         // Deploy mock deposit contract for testing
         mockDepositContract = new MockDepositContract();
-        figmentDepositor = new FigmentEth2Depositor(address(mockDepositContract));
+        figmentDepositor = new FigmentEth2DepositorV1(address(mockDepositContract));
     }
 
     // ============ Constructor Tests ============
 
     function test_Constructor_Success() public {
         address ethDepositContract = address(0x123);
-        FigmentEth2Depositor newFigmentEth2Depositor = new FigmentEth2Depositor(ethDepositContract);
+        FigmentEth2DepositorV1 newFigmentEth2DepositorV1 = new FigmentEth2DepositorV1(ethDepositContract);
 
-        assertEq(address(newFigmentEth2Depositor.depositContract()), ethDepositContract);
-        assertEq(newFigmentEth2Depositor.owner(), address(this));
+        assertEq(address(newFigmentEth2DepositorV1.depositContract()), ethDepositContract);
+        assertEq(newFigmentEth2DepositorV1.owner(), address(this));
     }
 
     function test_Constructor_ZeroAddress_Reverts() public {
-        vm.expectRevert(FigmentEth2Depositor.ZeroAddress.selector);
-        new FigmentEth2Depositor(address(0));
+        vm.expectRevert(FigmentEth2DepositorV1.ZeroAddress.selector);
+        new FigmentEth2DepositorV1(address(0));
     }
 
     // ============ Receive Function Tests ============
@@ -41,7 +41,7 @@ contract FigmentEth2DepositorTest is Test {
         uint256 preContractBalance = address(figmentDepositor).balance;
         uint256 preMockBalance = address(mockDepositContract).balance;
 
-        vm.expectRevert(FigmentEth2Depositor.DirectEthTransferNotAllowed.selector);
+        vm.expectRevert(FigmentEth2DepositorV1.DirectEthTransferNotAllowed.selector);
         address(figmentDepositor).call{value: 1 ether}("");
 
         // Capture post-transaction balances
@@ -134,7 +134,7 @@ contract FigmentEth2DepositorTest is Test {
         bytes32[] memory depositDataRoots = new bytes32[](0);
         uint256[] memory amountsGwei = new uint256[](0);
 
-        vm.expectRevert(abi.encodeWithSelector(FigmentEth2Depositor.ParametersMismatch.selector, 0, 500));
+        vm.expectRevert(abi.encodeWithSelector(FigmentEth2DepositorV1.ParametersMismatch.selector, 0, 500));
         figmentDepositor.deposit{value: 0}(pubkeys, withdrawalCredentials, signatures, depositDataRoots, amountsGwei);
     }
 
@@ -155,7 +155,7 @@ contract FigmentEth2DepositorTest is Test {
 
         uint256 totalValue = 32_000_000_000 * 1_000_000_000 * tooManyNodes; // Convert to wei
 
-        vm.expectRevert(abi.encodeWithSelector(FigmentEth2Depositor.ParametersMismatch.selector, tooManyNodes, 500));
+        vm.expectRevert(abi.encodeWithSelector(FigmentEth2DepositorV1.ParametersMismatch.selector, tooManyNodes, 500));
         figmentDepositor.deposit{value: totalValue}(
             pubkeys, withdrawalCredentials, signatures, depositDataRoots, amountsGwei
         );
@@ -172,7 +172,7 @@ contract FigmentEth2DepositorTest is Test {
             _createValidValidatorData(32_000_000_000);
         amountsGwei[0] = 32_000_000_000;
 
-        vm.expectRevert(abi.encodeWithSelector(FigmentEth2Depositor.ParametersMismatch.selector, 1, 0));
+        vm.expectRevert(abi.encodeWithSelector(FigmentEth2DepositorV1.ParametersMismatch.selector, 1, 0));
         figmentDepositor.deposit{value: 32 ether}(
             pubkeys, withdrawalCredentials, signatures, depositDataRoots, amountsGwei
         );
@@ -189,7 +189,7 @@ contract FigmentEth2DepositorTest is Test {
             _createValidValidatorData(32_000_000_000);
         amountsGwei[0] = 32_000_000_000;
 
-        vm.expectRevert(abi.encodeWithSelector(FigmentEth2Depositor.ParametersMismatch.selector, 1, 0));
+        vm.expectRevert(abi.encodeWithSelector(FigmentEth2DepositorV1.ParametersMismatch.selector, 1, 0));
         figmentDepositor.deposit{value: 32 ether}(
             pubkeys, withdrawalCredentials, signatures, depositDataRoots, amountsGwei
         );
@@ -206,7 +206,7 @@ contract FigmentEth2DepositorTest is Test {
             _createValidValidatorData(32_000_000_000);
         amountsGwei[0] = 32_000_000_000;
 
-        vm.expectRevert(abi.encodeWithSelector(FigmentEth2Depositor.ParametersMismatch.selector, 1, 0));
+        vm.expectRevert(abi.encodeWithSelector(FigmentEth2DepositorV1.ParametersMismatch.selector, 1, 0));
         figmentDepositor.deposit{value: 32 ether}(
             pubkeys, withdrawalCredentials, signatures, depositDataRoots, amountsGwei
         );
@@ -223,7 +223,7 @@ contract FigmentEth2DepositorTest is Test {
             _createValidValidatorData(32_000_000_000);
         amountsGwei[0] = 32_000_000_000;
 
-        vm.expectRevert(abi.encodeWithSelector(FigmentEth2Depositor.ParametersMismatch.selector, 1, 0));
+        vm.expectRevert(abi.encodeWithSelector(FigmentEth2DepositorV1.ParametersMismatch.selector, 1, 0));
         figmentDepositor.deposit{value: 32 ether}(
             pubkeys, withdrawalCredentials, signatures, depositDataRoots, amountsGwei
         );
@@ -244,7 +244,7 @@ contract FigmentEth2DepositorTest is Test {
         amountsGwei[0] = belowMinimum;
 
         vm.expectRevert(
-            abi.encodeWithSelector(FigmentEth2Depositor.InsufficientAmount.selector, belowMinimum, 32_000_000_000)
+            abi.encodeWithSelector(FigmentEth2DepositorV1.InsufficientAmount.selector, belowMinimum, 32_000_000_000)
         );
         figmentDepositor.deposit{value: belowMinimum * 1_000_000_000}(
             pubkeys, withdrawalCredentials, signatures, depositDataRoots, amountsGwei
@@ -264,7 +264,7 @@ contract FigmentEth2DepositorTest is Test {
         amountsGwei[0] = aboveMaximum;
 
         vm.expectRevert(
-            abi.encodeWithSelector(FigmentEth2Depositor.InsufficientAmount.selector, aboveMaximum, 2_048_000_000_000)
+            abi.encodeWithSelector(FigmentEth2DepositorV1.InsufficientAmount.selector, aboveMaximum, 2_048_000_000_000)
         );
         figmentDepositor.deposit{value: aboveMaximum * 1_000_000_000}(
             pubkeys, withdrawalCredentials, signatures, depositDataRoots, amountsGwei
@@ -287,7 +287,7 @@ contract FigmentEth2DepositorTest is Test {
         uint256 wrongValue = expectedValue + 1; // Send 1 wei too much
 
         vm.expectRevert(
-            abi.encodeWithSelector(FigmentEth2Depositor.EthAmountMismatch.selector, wrongValue, expectedValue)
+            abi.encodeWithSelector(FigmentEth2DepositorV1.EthAmountMismatch.selector, wrongValue, expectedValue)
         );
         figmentDepositor.deposit{value: wrongValue}(
             pubkeys, withdrawalCredentials, signatures, depositDataRoots, amountsGwei
@@ -315,7 +315,7 @@ contract FigmentEth2DepositorTest is Test {
         uint256 preMockBalance = address(mockDepositContract).balance;
 
         vm.expectRevert(
-            abi.encodeWithSelector(FigmentEth2Depositor.EthAmountMismatch.selector, wrongValue, expectedValue)
+            abi.encodeWithSelector(FigmentEth2DepositorV1.EthAmountMismatch.selector, wrongValue, expectedValue)
         );
         figmentDepositor.deposit{value: wrongValue}(
             pubkeys, withdrawalCredentials, signatures, depositDataRoots, amountsGwei
@@ -354,7 +354,7 @@ contract FigmentEth2DepositorTest is Test {
         uint256 totalValue = (32_000_000_000 + invalidAmount) * 1_000_000_000;
 
         vm.expectRevert(
-            abi.encodeWithSelector(FigmentEth2Depositor.InsufficientAmount.selector, invalidAmount, 32_000_000_000)
+            abi.encodeWithSelector(FigmentEth2DepositorV1.InsufficientAmount.selector, invalidAmount, 32_000_000_000)
         );
         figmentDepositor.deposit{value: totalValue}(
             pubkeys, withdrawalCredentials, signatures, depositDataRoots, amountsGwei
@@ -380,7 +380,7 @@ contract FigmentEth2DepositorTest is Test {
             _createValidValidatorDataWithoutPubkey(32_000_000_000);
         amountsGwei[0] = 32_000_000_000;
 
-        vm.expectRevert(abi.encodeWithSelector(FigmentEth2Depositor.InvalidValidatorData.selector, 0, "pubkey"));
+        vm.expectRevert(abi.encodeWithSelector(FigmentEth2DepositorV1.InvalidValidatorData.selector, 0, "pubkey"));
         figmentDepositor.deposit{value: 32 ether}(
             pubkeys, withdrawalCredentials, signatures, depositDataRoots, amountsGwei
         );
@@ -405,7 +405,7 @@ contract FigmentEth2DepositorTest is Test {
         amountsGwei[0] = 32_000_000_000;
 
         vm.expectRevert(
-            abi.encodeWithSelector(FigmentEth2Depositor.InvalidValidatorData.selector, 0, "withdrawal_credentials")
+            abi.encodeWithSelector(FigmentEth2DepositorV1.InvalidValidatorData.selector, 0, "withdrawal_credentials")
         );
         figmentDepositor.deposit{value: 32 ether}(
             pubkeys, wrongWithdrawalCredentials, signatures, depositDataRoots, amountsGwei
@@ -430,7 +430,7 @@ contract FigmentEth2DepositorTest is Test {
             _createValidValidatorData(32_000_000_000);
         amountsGwei[0] = 32_000_000_000;
 
-        vm.expectRevert(abi.encodeWithSelector(FigmentEth2Depositor.InvalidValidatorData.selector, 0, "signature"));
+        vm.expectRevert(abi.encodeWithSelector(FigmentEth2DepositorV1.InvalidValidatorData.selector, 0, "signature"));
         figmentDepositor.deposit{value: 32 ether}(
             pubkeys, withdrawalCredentials, wrongSignatures, depositDataRoots, amountsGwei
         );
@@ -459,7 +459,7 @@ contract FigmentEth2DepositorTest is Test {
 
         uint256 totalValue = 64 ether;
 
-        vm.expectRevert(abi.encodeWithSelector(FigmentEth2Depositor.InvalidValidatorData.selector, 1, "pubkey"));
+        vm.expectRevert(abi.encodeWithSelector(FigmentEth2DepositorV1.InvalidValidatorData.selector, 1, "pubkey"));
         figmentDepositor.deposit{value: totalValue}(
             pubkeys, withdrawalCredentials, signatures, depositDataRoots, amountsGwei
         );
@@ -536,9 +536,9 @@ contract FigmentEth2DepositorTest is Test {
             abi.encodePacked(uint64(1))
         );
 
-        // Expect the FigmentEth2Depositor event SECOND (it's emitted after the deposit)
+        // Expect the FigmentEth2DepositorV1 event SECOND (it's emitted after the deposit)
         vm.expectEmit(true, true, true, true);
-        emit FigmentEth2Depositor.DepositEvent(address(this), 1, totalValue);
+        emit FigmentEth2DepositorV1.DepositEvent(address(this), 1, totalValue);
 
         figmentDepositor.deposit{value: totalValue}(
             pubkeys, withdrawalCredentials, signatures, depositDataRoots, amountsGwei
@@ -568,7 +568,7 @@ contract FigmentEth2DepositorTest is Test {
 
         // Execute successful deposit
         vm.expectEmit(true, true, true, true);
-        emit FigmentEth2Depositor.DepositEvent(address(this), 1, totalValue);
+        emit FigmentEth2DepositorV1.DepositEvent(address(this), 1, totalValue);
 
         figmentDepositor.deposit{value: totalValue}(
             pubkeys, withdrawalCredentials, signatures, depositDataRoots, amountsGwei
@@ -635,7 +635,7 @@ contract FigmentEth2DepositorTest is Test {
         );
 
         vm.expectEmit(true, true, true, true);
-        emit FigmentEth2Depositor.DepositEvent(address(this), validatorCount, totalValue);
+        emit FigmentEth2DepositorV1.DepositEvent(address(this), validatorCount, totalValue);
 
         figmentDepositor.deposit{value: totalValue}(
             pubkeys, withdrawalCredentials, signatures, depositDataRoots, amountsGwei
@@ -664,7 +664,7 @@ contract FigmentEth2DepositorTest is Test {
 
         // Expect DepositEvent to be emitted
         vm.expectEmit(true, true, true, true);
-        emit FigmentEth2Depositor.DepositEvent(address(this), validatorCount, totalValue);
+        emit FigmentEth2DepositorV1.DepositEvent(address(this), validatorCount, totalValue);
 
         figmentDepositor.deposit{value: totalValue}(
             pubkeys, withdrawalCredentials, signatures, depositDataRoots, amountsGwei
@@ -697,7 +697,7 @@ contract FigmentEth2DepositorTest is Test {
 
         // Expect DepositEvent to be emitted
         vm.expectEmit(true, true, true, true);
-        emit FigmentEth2Depositor.DepositEvent(address(this), 2, totalValue);
+        emit FigmentEth2DepositorV1.DepositEvent(address(this), 2, totalValue);
 
         figmentDepositor.deposit{value: totalValue}(
             pubkeys, withdrawalCredentials, signatures, depositDataRoots, amountsGwei
@@ -766,7 +766,7 @@ contract FigmentEth2DepositorTest is Test {
         );
 
         vm.expectEmit(true, true, true, true);
-        emit FigmentEth2Depositor.DepositEvent(address(this), 4, totalValue);
+        emit FigmentEth2DepositorV1.DepositEvent(address(this), 4, totalValue);
 
         figmentDepositor.deposit{value: totalValue}(
             pubkeys, withdrawalCredentials, signatures, depositDataRoots, amountsGwei
@@ -790,7 +790,7 @@ contract FigmentEth2DepositorTest is Test {
         uint256 totalValue = amountGwei * 1_000_000_000;
 
         // Call with no ETH value
-        vm.expectRevert(abi.encodeWithSelector(FigmentEth2Depositor.EthAmountMismatch.selector, 0, totalValue));
+        vm.expectRevert(abi.encodeWithSelector(FigmentEth2DepositorV1.EthAmountMismatch.selector, 0, totalValue));
         figmentDepositor.deposit{value: 0}(pubkeys, withdrawalCredentials, signatures, depositDataRoots, amountsGwei);
     }
 
@@ -902,7 +902,7 @@ contract FigmentEth2DepositorTest is Test {
         uint256 totalValue = amountGwei * 1_000_000_000;
 
         vm.expectEmit(true, true, true, true);
-        emit FigmentEth2Depositor.DepositEvent(address(this), 1, totalValue);
+        emit FigmentEth2DepositorV1.DepositEvent(address(this), 1, totalValue);
 
         figmentDepositor.deposit{value: totalValue}(
             pubkeys, withdrawalCredentials, signatures, depositDataRoots, amountsGwei

--- a/docs/FigmentEth2DepositorV0/README.md
+++ b/docs/FigmentEth2DepositorV0/README.md
@@ -1,0 +1,29 @@
+## FigmentEth2DepositorV0 Contract
+
+> This contract used to be named "FigmentEth2Depositor" – when you see an unversioned name for the contract, you can assume it is V0.
+
+The Figment Eth2 Depositor provides a convenient way to send 1 or more deposits in one transaction to the Eth2 Deposit Contract when the deposit amount is 32 ETH for each validator.
+
+### Contract Addresses
+
+- Contract address on mainnet: `0x00000000219ab540356cBB839Cbe05303d7705Fa`
+- Contract address on (Hoodi) testnet: `0x00000000219ab540356cBB839Cbe05303d7705Fa`
+
+Below is a list of contracts we use for this service:
+
+<dl>
+  <dt>Ownable, Pausable</dt>
+  <dd>OpenZepellin smart contracts. The first contract allows for managing ownership. The second contract allows for pausing the contract and vice versa.</dd>
+</dl>
+
+<dl>
+  <dt>FigmentEth2DepositorV0</dt>
+  <dd>A smart contract that accepts X amount of ETH and sends {x / 32} transactions with required collateral (32 ETH) to the Eth2 Deposit Contract.</dd>
+</dl>
+
+### How to Use
+
+1. Choose the amount of Eth2 validator nodes you want to deposit to.
+2. Instantiate those validators with your chosen `withdrawal_credentials`
+3. Retrieve your validators' `pubkeys`, and generate `deposit_signatures` and `deposit_data_roots` from each that will let you deposit to them.
+4. Use the _deposit()_ function on `FigmentEth2DepositorV0` with the required ETH value to make the deposits to the Eth2 Deposit Contract.

--- a/docs/FigmentEth2DepositorV1/optimizations.md
+++ b/docs/FigmentEth2DepositorV1/optimizations.md
@@ -1,4 +1,4 @@
-# FigmentEth2Depositor Optimizations
+# FigmentEth2DepositorV1 Optimizations
 
 ## Withdrawal Credentials Validation
 

--- a/ignition/modules/FigmentEth2DepositorV0.ts
+++ b/ignition/modules/FigmentEth2DepositorV0.ts
@@ -1,11 +1,11 @@
 import { buildModule } from "@nomicfoundation/hardhat-ignition/modules";
 
-export default buildModule("FigmentEth2DepositorModule", (m) => {
+export default buildModule("FigmentEth2DepositorV0Module", (m) => {
   // Ethereum 2.0 deposit contract address (mainnet)
   // This is also the same address on hoodi testnet
   const depositContractAddress = m.getParameter("depositContract", "0x00000000219ab540356cBB839Cbe05303d7705Fa");
 
-  const depositor = m.contract("FigmentEth2Depositor", [depositContractAddress]);
+  const depositor = m.contract("FigmentEth2DepositorV0", [depositContractAddress]);
 
   return { depositor };
 });

--- a/ignition/modules/FigmentEth2DepositorV1.ts
+++ b/ignition/modules/FigmentEth2DepositorV1.ts
@@ -1,0 +1,11 @@
+import { buildModule } from "@nomicfoundation/hardhat-ignition/modules";
+
+export default buildModule("FigmentEth2DepositorV1Module", (m) => {
+  // Ethereum 2.0 deposit contract address (mainnet)
+  // This is also the same address on hoodi testnet
+  const depositContractAddress = m.getParameter("depositContract", "0x00000000219ab540356cBB839Cbe05303d7705Fa");
+
+  const depositor = m.contract("FigmentEth2DepositorV1", [depositContractAddress]);
+
+  return { depositor };
+});

--- a/metadata/clear-signing-descriptor.json
+++ b/metadata/clear-signing-descriptor.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/LedgerHQ/clear-signing-erc7730-registry/master/schemas/erc7730.schema.json",
   "metadata": {
-    "name": "FigmentEth2Depositor",
+    "name": "FigmentEth2DepositorV1",
     "description": "Batch Ethereum 2.0 validator deposit contract with variable amounts",
     "version": "1.0.0",
     "owner": "Figment",
@@ -16,7 +16,7 @@
     "eip712": null,
     "contract": {
       "abi": {
-        "url": "https://raw.githubusercontent.com/figment-networks/figment-eth2-depositor/main/artifacts/contracts/FigmentEth2Depositor.sol/FigmentEth2Depositor.json"
+        "url": "https://raw.githubusercontent.com/figment-networks/figment-eth2-depositor/main/artifacts/contracts/FigmentEth2DepositorV1.sol/FigmentEth2DepositorV1.json"
       },
       "deployments": [
         {
@@ -33,8 +33,8 @@
   "display": {
     "intent": {
       "deposit": "Stake {{amounts_gwei.length}} validators with total {{msg.value}} ETH on Ethereum 2.0",
-      "pause": "Pause the FigmentEth2Depositor contract",
-      "unpause": "Unpause the FigmentEth2Depositor contract"
+      "pause": "Pause the FigmentEth2DepositorV1 contract",
+      "unpause": "Unpause the FigmentEth2DepositorV1 contract"
     },
     "formats": {
       "gwei_to_eth": {

--- a/metadata/human-readable-abi.json
+++ b/metadata/human-readable-abi.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/LedgerHQ/clear-signing-erc7730-registry/master/schemas/erc7730.schema.json",
   "metadata": {
-    "name": "FigmentEth2Depositor ABI Definitions",
-    "description": "Human-readable ABI and function descriptions for FigmentEth2Depositor contract",
+    "name": "FigmentEth2DepositorV1 ABI Definitions",
+    "description": "Human-readable ABI and function descriptions for FigmentEth2DepositorV1 contract",
     "version": "1.0.0",
     "erc7730_compatible": true
   },
@@ -31,13 +31,13 @@
       "title": "Pause Contract",
       "summary": "Temporarily disable new deposits",
       "details": "Prevents new validator deposits until unpaused. Only the contract owner can perform this action.",
-      "erc7730_intent": "Pause the FigmentEth2Depositor contract"
+      "erc7730_intent": "Pause the FigmentEth2DepositorV1 contract"
     },
     "unpause": {
       "title": "Unpause Contract",
       "summary": "Re-enable deposits",
       "details": "Allows new validator deposits again. Only the contract owner can perform this action.",
-      "erc7730_intent": "Unpause the FigmentEth2Depositor contract"
+      "erc7730_intent": "Unpause the FigmentEth2DepositorV1 contract"
     }
   },
   "erc7730_field_mappings": {

--- a/metadata/wallet-integration-guide.md
+++ b/metadata/wallet-integration-guide.md
@@ -1,10 +1,10 @@
 # ERC-7730 Clear Signing Integration Guide
 
-This guide helps wallet developers integrate ERC-7730 compliant clear signing support for the FigmentEth2Depositor contract.
+This guide helps wallet developers integrate ERC-7730 compliant clear signing support for the FigmentEth2DepositorV1 contract.
 
 ## Overview
 
-The FigmentEth2Depositor contract creates multiple Ethereum 2.0 validators in a single transaction with custom stake amounts. This guide provides ERC-7730 standard implementation details for enhanced clear signing. The ERC-7730 format provides standardized metadata that helps users understand:
+The FigmentEth2DepositorV1 contract creates multiple Ethereum 2.0 validators in a single transaction with custom stake amounts. This guide provides ERC-7730 standard implementation details for enhanced clear signing. The ERC-7730 format provides standardized metadata that helps users understand:
 
 1. **What they're doing**: Creating Ethereum 2.0 validators
 2. **How much they're staking**: Total ETH and per-validator amounts
@@ -309,7 +309,7 @@ To submit to the [ERC-7730 registry](https://github.com/LedgerHQ/clear-signing-e
 Update the ABI URL in the descriptor once published:
 ```json
 "abi": {
-  "url": "https://raw.githubusercontent.com/figment-networks/figment-eth2-depositor/main/artifacts/contracts/FigmentEth2Depositor.sol/FigmentEth2Depositor.json"
+  "url": "https://raw.githubusercontent.com/figment-networks/figment-eth2-depositor/main/artifacts/contracts/FigmentEth2DepositorV1.sol/FigmentEth2DepositorV1.json"
 }
 ```
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,13 +1,13 @@
 # Analysis and Monitoring Scripts
 
-This directory contains scripts for gas analysis and event monitoring for the FigmentEth2Depositor contracts.
+This directory contains scripts for gas analysis and event monitoring for the FigmentEth2DepositorV1 contracts.
 
 ## Scripts Overview
 
 ### 1. `analyze-gas.ts`
 **Gas cost comparison between new and legacy contracts**
 
-Analyzes and compares gas costs between the new `FigmentEth2Depositor` (variable amounts) and legacy `FigmentEth2Depositor0x01` (fixed 32 ETH) contracts. Provides detailed gas usage reports with cost calculations.
+Analyzes and compares gas costs between the new `FigmentEth2DepositorV1` (variable amounts) and legacy `FigmentEth2DepositorV0` (fixed 32 ETH) contracts. Provides detailed gas usage reports with cost calculations.
 
 ```bash
 # Run gas analysis comparison

--- a/scripts/analyze-gas.ts
+++ b/scripts/analyze-gas.ts
@@ -20,8 +20,8 @@ async function main() {
 
   // Deploy contracts
   console.log("Deploying test contracts...");
-  const newContract = await viem.deployContract("FigmentEth2Depositor", [mockDepositContract]);
-  const legacyContract = await viem.deployContract("FigmentEth2Depositor0x01", [mockDepositContract]);
+  const newContract = await viem.deployContract("FigmentEth2DepositorV1", [mockDepositContract]);
+  const legacyContract = await viem.deployContract("FigmentEth2DepositorV0", [mockDepositContract]);
 
   console.log(`✅ New Contract deployed at: ${newContract.address}`);
   console.log(`✅ Legacy Contract deployed at: ${legacyContract.address}\n`);

--- a/scripts/demo-event-monitoring.ts
+++ b/scripts/demo-event-monitoring.ts
@@ -125,7 +125,7 @@ async function demoEventMonitoring() {
 
   // Deploy Figment contract
   console.log("📦 Deploying Figment contract...");
-  const figmentContract = await viem.deployContract("FigmentEth2Depositor", [mockDepositContract.address]);
+  const figmentContract = await viem.deployContract("FigmentEth2DepositorV1", [mockDepositContract.address]);
   console.log(`✅ Figment Contract: ${figmentContract.address}`);
   console.log("");
 

--- a/test/FigmentEth2DepositorV0.ts
+++ b/test/FigmentEth2DepositorV0.ts
@@ -3,14 +3,14 @@ import { describe, it } from "node:test";
 
 import { network } from "hardhat";
 
-describe("FigmentEth2Depositor0x01", async function () {
+describe("FigmentEth2DepositorV0", async function () {
   const { viem } = await network.connect();
   const publicClient = await viem.getPublicClient();
 
   it("Should deploy with correct deposit contract address", async function () {
     const mockDepositContract = "0x00000000219ab540356cBB839Cbe05303d7705Fa"; // Ethereum 2.0 deposit contract
 
-    const depositor = await viem.deployContract("FigmentEth2Depositor0x01", [mockDepositContract]);
+    const depositor = await viem.deployContract("FigmentEth2DepositorV0", [mockDepositContract]);
 
     // Check that the contract was deployed
     assert.ok(depositor.address);
@@ -21,14 +21,14 @@ describe("FigmentEth2Depositor0x01", async function () {
       abi: depositor.abi,
       functionName: "depositContract",
       args: [],
-    });
+    }) as string;
 
     assert.equal(contractDepositContract.toLowerCase(), mockDepositContract.toLowerCase());
   });
 
   it("Should be initially unpaused", async function () {
     const mockDepositContract = "0x00000000219ab540356cBB839Cbe05303d7705Fa";
-    const depositor = await viem.deployContract("FigmentEth2Depositor0x01", [mockDepositContract]);
+    const depositor = await viem.deployContract("FigmentEth2DepositorV0", [mockDepositContract]);
 
     const paused = await publicClient.readContract({
       address: depositor.address,

--- a/test/FigmentEth2DepositorV1.ts
+++ b/test/FigmentEth2DepositorV1.ts
@@ -4,7 +4,7 @@ import { describe, it } from "node:test";
 import { network } from "hardhat";
 import { parseGwei } from "viem";
 
-describe("FigmentEth2Depositor", async function () {
+describe("FigmentEth2DepositorV1", async function () {
   const { viem } = await network.connect();
   const publicClient = await viem.getPublicClient();
 
@@ -12,7 +12,7 @@ describe("FigmentEth2Depositor", async function () {
     // Mock deposit contract address (for testing)
     const mockDepositContract = "0x00000000219ab540356cBB839Cbe05303d7705Fa"; // Ethereum 2.0 deposit contract
 
-    const depositor = await viem.deployContract("FigmentEth2Depositor", [mockDepositContract]);
+    const depositor = await viem.deployContract("FigmentEth2DepositorV1", [mockDepositContract]);
 
     // Check that the contract was deployed
     assert.ok(depositor.address);
@@ -23,14 +23,14 @@ describe("FigmentEth2Depositor", async function () {
       abi: depositor.abi,
       functionName: "depositContract",
       args: [],
-    });
+    }) as string;
 
     assert.equal(contractDepositContract.toLowerCase(), mockDepositContract.toLowerCase());
   });
 
   it("Should be initially unpaused", async function () {
     const mockDepositContract = "0x00000000219ab540356cBB839Cbe05303d7705Fa";
-    const depositor = await viem.deployContract("FigmentEth2Depositor", [mockDepositContract]);
+    const depositor = await viem.deployContract("FigmentEth2DepositorV1", [mockDepositContract]);
 
     const paused = await publicClient.readContract({
       address: depositor.address,
@@ -44,7 +44,7 @@ describe("FigmentEth2Depositor", async function () {
 
   it("Should validate deposit parameters for variable amounts", async function () {
     const mockDepositContract = "0x00000000219ab540356cBB839Cbe05303d7705Fa";
-    const depositor = await viem.deployContract("FigmentEth2Depositor", [mockDepositContract]);
+    const depositor = await viem.deployContract("FigmentEth2DepositorV1", [mockDepositContract]);
 
     // Test data for multiple validators with different amounts
     const pubkeys = [

--- a/test/GasComparison.ts
+++ b/test/GasComparison.ts
@@ -30,8 +30,8 @@ describe("Gas Cost Comparison: New vs Legacy", async function () {
     console.log(`✅ Mock Deposit Contract deployed at: ${mockDepositContract}\n`);
 
     // Deploy both contracts
-    const newContract = await viem.deployContract("FigmentEth2Depositor", [mockDepositContract]);
-    const legacyContract = await viem.deployContract("FigmentEth2Depositor0x01", [mockDepositContract]);
+    const newContract = await viem.deployContract("FigmentEth2DepositorV1", [mockDepositContract]);
+    const legacyContract = await viem.deployContract("FigmentEth2DepositorV0", [mockDepositContract]);
 
     console.log("Contracts deployed:");
     console.log(`  New Contract: ${newContract.address}`);
@@ -134,8 +134,8 @@ describe("Gas Cost Comparison: New vs Legacy", async function () {
     const testMockContract = await deployMockDepositContract();
 
     // Get deployment gas estimates
-    const newDeployment = await viem.deployContract("FigmentEth2Depositor", [testMockContract]);
-    const legacyDeployment = await viem.deployContract("FigmentEth2Depositor0x01", [testMockContract]);
+    const newDeployment = await viem.deployContract("FigmentEth2DepositorV1", [testMockContract]);
+    const legacyDeployment = await viem.deployContract("FigmentEth2DepositorV0", [testMockContract]);
 
     // Get contract bytecode sizes
     const newBytecode = await publicClient.getCode({ address: newDeployment.address });


### PR DESCRIPTION
I renamed the contracts to FigmentEth2DepositorV0 and FigmentEth2DepositorV1 to avoid confusion about which one is which.