### PR TITLE
Cleans up the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 1. Clone the repository `git clone git@github.com:figment-networks/figment-eth2-depositor.git`
 2. Install the npm dependencies `pnpm install`
 
-
 ## Usage
 
 ### Running Tests
@@ -25,55 +24,26 @@ pnpm hardhat test nodejs
 
 ### Make a deployment to Sepolia
 
-This project includes an example Ignition module to deploy the contract. You can deploy this module to a locally simulated chain or to Sepolia.
+This project includes an example Ignition module to deploy the contract. You can deploy this module to a locally simulated chain or to Hoodi.
 
 To run the deployment to a local chain:
 
 ```shell
-pnpm hardhat ignition deploy ignition/modules/FigmentEth2DepositorV0.ts
+pnpm hardhat ignition deploy ignition/modules/FigmentEth2DepositorV1.ts
 ```
 
-To run the deployment to Sepolia, you need an account with funds to send the transaction. The provided Hardhat configuration includes a Configuration Variable called `SEPOLIA_PRIVATE_KEY`, which you can use to set the private key of the account you want to use.
+To run the deployment to Hoodi, you need an account with funds to send the transaction. The provided Hardhat configuration includes a Configuration Variable called `HOODI_PRIVATE_KEY`, which you can use to set the private key of the account you want to use.
 
-You can set the `SEPOLIA_PRIVATE_KEY` variable using the `hardhat-keystore` plugin or by setting it as an environment variable.
+You can set the `HOODI_PRIVATE_KEY` variable using the `hardhat-keystore` plugin or by setting it as an environment variable.
 
-To set the `SEPOLIA_PRIVATE_KEY` config variable using `hardhat-keystore`:
+To set the `HOODI_PRIVATE_KEY` config variable using `hardhat-keystore`:
 
 ```shell
-pnpm hardhat keystore set SEPOLIA_PRIVATE_KEY
+pnpm hardhat keystore set HOODI_PRIVATE_KEY
 ```
 
 After setting the variable, you can run the deployment with the Sepolia network:
 
 ```shell
-pnpm hardhat ignition deploy --network sepolia ignition/modules/Counter.ts
+pnpm hardhat ignition deploy --network hoodi ignition/modules/FigmentEth2DepositorV1.ts
 ```
-
-
-## FigmentEth2Depositor0x01 Contract
-
-The Figment Eth2 Depositor provides a convenient way to send 1 or more deposits in one transaction to the Eth2 Deposit Contract when the deposit amount is 32 ETH for each validator.
-
-### Contract Addresses
-
-- Contract address on mainnet: `0x00000000219ab540356cBB839Cbe05303d7705Fa`
-- Contract address on (Hoodi) testnet: `0x00000000219ab540356cBB839Cbe05303d7705Fa`
-
-Below is a list of contracts we use for this service:
-
-<dl>
-  <dt>Ownable, Pausable</dt>
-  <dd>OpenZepellin smart contracts. The first contract allows for managing ownership. The second contract allows for pausing the contract and vice versa.</dd>
-</dl>
-
-<dl>
-  <dt>FigmentEth2DepositorV0</dt>
-  <dd>A smart contract that accepts X amount of ETH and sends {x / 32} transactions with required collateral (32 ETH) to the Eth2 Deposit Contract.</dd>
-</dl>
-
-### How to Use
-
-1. Choose the amount of Eth2 validator nodes you want to deposit to.
-2. Instantiate those validators with your chosen `withdrawal_credentials`
-3. Retrieve your validators' `pubkeys`, and generate `deposit_signatures` and `deposit_data_roots` from each that will let you deposit to them.
-4. Use the _deposit()_ function on `FigmentEth2DepositorV0` with the required ETH value to make the deposits to the Eth2 Deposit Contract.


### PR DESCRIPTION
- Removes a section of the README which has been migrated to the `docs/` directory.
- Updates the README to show an example of how to deploy to Hoodi rather than Sepolia.