### PR TITLE
Oops, forgot the config I referenced in the readme

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -46,6 +46,12 @@ const config: HardhatUserConfig = {
       url: configVariable("SEPOLIA_RPC_URL"),
       accounts: [configVariable("SEPOLIA_PRIVATE_KEY")],
     },
+    hoodi: {
+      type: "http",
+      chainType: "l1",
+      url: configVariable("HOODI_RPC_URL"),
+      accounts: [configVariable("HOODI_PRIVATE_KEY")],
+    },
   },
 };
 


### PR DESCRIPTION
This adds a config to allow hardhat to deploy to hoodi. I included instructions in README, but forgot to re-add this config in the hardhat config.